### PR TITLE
Allow for /metrics path to be configurable

### DIFF
--- a/_examples/basic/main.go
+++ b/_examples/basic/main.go
@@ -32,7 +32,6 @@ func main() {
 	// with prometheus metrics collector.
 	r.Use(telemetry.Collector(telemetry.Config{
 		AllowAny: true,
-		HTTPPath: "/metrics",
 	}, []string{"/api"})) // path prefix filters records generic http request metrics
 
 	r.Route("/api", func(r chi.Router) {

--- a/_examples/basic/main.go
+++ b/_examples/basic/main.go
@@ -9,9 +9,7 @@ import (
 	"github.com/go-chi/telemetry"
 )
 
-var (
-	AppMetrics = &MyAppMetrics{telemetry.NewScope("app")}
-)
+var AppMetrics = &MyAppMetrics{telemetry.NewScope("app")}
 
 type MyAppMetrics struct {
 	*telemetry.Scope
@@ -34,6 +32,7 @@ func main() {
 	// with prometheus metrics collector.
 	r.Use(telemetry.Collector(telemetry.Config{
 		AllowAny: true,
+		HTTPPath: "/metrics",
 	}, []string{"/api"})) // path prefix filters records generic http request metrics
 
 	r.Route("/api", func(r chi.Router) {

--- a/collector.go
+++ b/collector.go
@@ -64,7 +64,14 @@ func Collector(cfg Config, optPathPrefixFilters ...[]string) func(next http.Hand
 
 	metricsPath := cfg.HTTPPath
 
-	if s := strings.Trim(cfg.HTTPPath, " "); len(s) > 0 {
+	switch len(strings.Trim(metricsPath, "")) {
+
+	case 0:
+		metricsPath = "/metrics"
+	default:
+
+		s := metricsPath
+
 		if s[0] != '/' {
 			s = "/" + s
 		}

--- a/collector.go
+++ b/collector.go
@@ -22,9 +22,7 @@ func Collector(cfg Config, optPathPrefixFilters ...[]string) func(next http.Hand
 
 	pathPrefixFilters := []string{}
 	if len(optPathPrefixFilters) > 0 {
-		for _, v := range optPathPrefixFilters[0] {
-			pathPrefixFilters = append(pathPrefixFilters, v)
-		}
+		pathPrefixFilters = append(pathPrefixFilters, optPathPrefixFilters[0]...)
 	}
 
 	authHandler := middleware.BasicAuth(
@@ -35,7 +33,6 @@ func Collector(cfg Config, optPathPrefixFilters ...[]string) func(next http.Hand
 	metricsHandler := chi.Chain(
 		func(next http.Handler) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
 				// Maybe allow internal traffic
 				if cfg.AllowInternal {
 					ipAddress := net.ParseIP(getIPAddress(r))
@@ -65,9 +62,19 @@ func Collector(cfg Config, optPathPrefixFilters ...[]string) func(next http.Hand
 		},
 	)
 
+	metricsPath := cfg.HTTPPath
+
+	if s := strings.Trim(cfg.HTTPPath, " "); len(s) > 0 {
+		if s[0] != '/' {
+			s = "/" + s
+		}
+
+		metricsPath = s
+	}
+
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.Method == "GET" && strings.EqualFold(r.URL.Path, "/metrics") {
+			if r.Method == "GET" && strings.EqualFold(r.URL.Path, metricsPath) {
 				// serve metrics page
 				metricsHandler.Handler(next).ServeHTTP(w, r)
 				return

--- a/config.go
+++ b/config.go
@@ -12,4 +12,8 @@ type Config struct {
 
 	// Allow internal private subnet traffic
 	AllowInternal bool `toml:"allow_internal"`
+
+	// Defines the path the metrics data would be mounted.
+	// If not provided, it defaults to /metrics
+	HTTPPath string `toml:"http_path"`
 }


### PR DESCRIPTION
I have added a new `HTTPPath` config value that takes a valid HTTP path and uses that if provided instead of the
default `/metrics`. This can be useful for toolings/OSS projects using this library that might want to allow their users
configure this