### PR TITLE
add posibility of incrementing any given value

### DIFF
--- a/telemetry.go
+++ b/telemetry.go
@@ -75,6 +75,11 @@ func (n *Scope) RecordHit(measurement string, tags map[string]string) {
 	record.Inc(1.0)
 }
 
+func (n *Scope) RecordIncrementValue(measurement string, tags map[string]string, value int64) {
+	record := n.scope.Tagged(tags).Counter(fmt.Sprintf(measurement + "_total"))
+	record.Inc(value)
+}
+
 // RecordGauge sets the value of a measurement that can go up or down over
 // time.
 //


### PR DESCRIPTION
- I feel like it is missing in the actual API contract. There is only `RecordHit` public API, but it does not give me possibility of incrementing different value than `1`. 