### PR TITLE
replace dot characters with underscore

### DIFF
--- a/telemetry.go
+++ b/telemetry.go
@@ -175,5 +175,6 @@ func (n *Scope) RecordDurationWithResolution(measurement string, tags map[string
 func newRootScope(opts tally.ScopeOptions, interval time.Duration) (tally.Scope, io.Closer) {
 	opts.CachedReporter = reporter
 	opts.Separator = prometheus.DefaultSeparator
+	opts.SanitizeOptions = &prometheus.DefaultSanitizerOpts
 	return tally.NewRootScope(opts, interval)
 }


### PR DESCRIPTION
This new allocation section is causing the panics: https://github.com/uber-go/tally/compare/v4.1.10...v4.1.11#diff-f65e5374d781f61272558959f338307fc0e51e9f59c0c75dc76d03dfd9dd2010R106

It tries to register internal tally metrics which contains `.` and that character is not allowed. Therefore replacing the dot character with underscore using `prometheus.DefaultSanitizerOpts` helps with preventhing this panic to happen. 

```
	// Metrics related.
	counterCardinalityName   = "tally.internal.counter_cardinality"
	gaugeCardinalityName     = "tally.internal.gauge_cardinality"
	histogramCardinalityName = "tally.internal.histogram_cardinality"
	scopeCardinalityName     = "tally.internal.num_active_scopes"
``` 

With that said in my opinion the registration of the internal metrics should happen only when `omitCardinalityMetrics` is false and also the metrics should have been defined with underscore by default. 

```
func newRootScope(opts tally.ScopeOptions, interval time.Duration) (tally.Scope, io.Closer) {
	opts.CachedReporter = reporter
	opts.Separator = prometheus.DefaultSeparator
	opts.OmitCardinalityMetrics = true
	return tally.NewRootScope(opts, interval)
}
``` 

I could register the scope like this and the panic should not happen.


@pkieltyka @VojtechVitek 
