### PR TITLE
Omit cardinality metrics

### DIFF
--- a/telemetry.go
+++ b/telemetry.go
@@ -176,5 +176,6 @@ func newRootScope(opts tally.ScopeOptions, interval time.Duration) (tally.Scope,
 	opts.CachedReporter = reporter
 	opts.Separator = prometheus.DefaultSeparator
 	opts.SanitizeOptions = &prometheus.DefaultSanitizerOpts
+	opts.OmitCardinalityMetrics = true
 	return tally.NewRootScope(opts, interval)
 }


### PR DESCRIPTION
Omit tally internal metrics
![image](https://github.com/go-chi/telemetry/assets/6400599/e4ec6e0f-de1d-4ff8-b30a-21e5b1933b44)

- Extra metrics were collected
- It was causing a race condition without this flag being set to `true` -> https://github.com/uber-go/tally/pull/247
