### PR TITLE
expose http.Handler to serve /metrics separately from main router

### DIFF
--- a/config.go
+++ b/config.go
@@ -12,6 +12,10 @@ type Config struct {
 
 	// Allow internal private subnet traffic
 	AllowInternal bool `toml:"allow_internal"`
+
+	// Useful when exposing the metrics endpoint on a separate server,
+	// then the ones from we collect metrics
+	CollectHttpRequestMetrics bool `toml:"collect_http_request_metrics"`
 }
 
 func (a Config) Creds() map[string]string {

--- a/http.go
+++ b/http.go
@@ -12,6 +12,16 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 )
 
+// Gives ability to exposes metrics on a separate http server.
+// Example usage to expose `/metrics` endpoint on port `9093` using go std lib http server:
+//
+//	metricsServer := http.NewServeMux()
+//	metricsServer.Handle("/metrics", telemetry.MetricsHandler())
+//	err := http.ListenAndServe(":9093", metricsServer)
+func MetricsHandler() http.Handler {
+	return reporter.HTTPHandler()
+}
+
 // Collector creates a handler that exposes a /metrics endpoint. Passing
 // an array of strings to pathPrefixFilters will help reduce the noise on the service
 // from random Internet traffic; that is, only the path prefixes will be measured.

--- a/http.go
+++ b/http.go
@@ -18,6 +18,9 @@ import (
 //	metricsServer := http.NewServeMux()
 //	metricsServer.Handle("/metrics", telemetry.MetricsHandler())
 //	err := http.ListenAndServe(":9093", metricsServer)
+//
+// If you want to also collect http request details as metrics,
+// please remember to configure it by setting Config.CollectHttpRequestMetrics to true
 func MetricsHandler() http.Handler {
 	return reporter.HTTPHandler()
 }
@@ -26,7 +29,7 @@ func MetricsHandler() http.Handler {
 // an array of strings to pathPrefixFilters will help reduce the noise on the service
 // from random Internet traffic; that is, only the path prefixes will be measured.
 func Collector(cfg Config, optPathPrefixFilters ...[]string) func(next http.Handler) http.Handler {
-	if (!cfg.AllowAny && !cfg.AllowInternal) && (cfg.Username == "" || cfg.Password == "") {
+	if (!cfg.AllowAny && !cfg.AllowInternal && !cfg.CollectHttpRequestMetrics) && (cfg.Username == "" || cfg.Password == "") {
 		return func(next http.Handler) http.Handler {
 			return next
 		}


### PR DESCRIPTION
Adds a simple public function to expose the prometheus `reporter.HTTPHandler` to allow exposing metrics on a separate server then the server that collects them.
Motivation why it is useful, when running the application inside secure environment it good practice to expose only the public facing api to outside world and keep metrics behind a firewall as they might expose useful informations to malicious users.
Not sure if the current place (next to `Collector()` inside `collector.go`) is the right one, but I'm willing to do any necessary changes to get this merged, thanks.